### PR TITLE
Use UIView designated initializer

### DIFF
--- a/Classes/ios/ORStackView.m
+++ b/Classes/ios/ORStackView.m
@@ -20,15 +20,20 @@
 
 @implementation ORStackView
 
-- (instancetype)init
+- (instancetype)initWithFrame:(CGRect)frame
 {
-    self = [super init];
+    self = [super initWithFrame:frame];
     if (!self) return nil;
-
+    
     _viewStack = [NSMutableArray array];
     _bottomMarginHeight = NSNotFound;
-
+    
     return self;
+}
+
+- (instancetype)init
+{
+    return [self initWithFrame:CGRectZero];
 }
 
 - (void)updateConstraints


### PR DESCRIPTION
Ran into issues testing ORStackView subclasses in isolation - since they don't use initWithFrame, they don't have any bounds and get a null CGContextRef when attempting to render the layer.
