### PR TITLE
Fix removing stale constraints

### DIFF
--- a/Classes/ios/ORStackView.m
+++ b/Classes/ios/ORStackView.m
@@ -40,7 +40,7 @@
 {
     // Remove all constraints
     for (StackView *stackView in self.viewStack) {
-        [stackView.view removeConstraint:stackView.topConstraint];
+        [self removeConstraint:stackView.topConstraint];
     }
 
     // Add the new constraints


### PR DESCRIPTION
I was encountering autolayout constraint errors when inserting a tagged view into the middle of the viewStack after all other views had been created and inserted. When updating constraints, the old topContraints for each stackView were not being removed, as removeContstraint was being called for the wrong view. Since the constraints are being added to `self` when created, then need to be removed form `self` accordingly.
