### PR TITLE
update margin inversion to allow for greater than or less than symbols

### DIFF
--- a/Classes/ios/ORStackView.m
+++ b/Classes/ios/ORStackView.m
@@ -136,14 +136,22 @@
     [self.viewStack insertObject:stackView atIndex:index];
 
     if (centered) {
-        NSString *invertedSideMargin = nil;
-        if ([sideMargin rangeOfString:@"-"].location == NSNotFound) {
-            invertedSideMargin = [@"-" stringByAppendingString:sideMargin];
+        NSMutableString *mutableSideMargin = sideMargin;
+        if ([mutableSideMargin rangeOfString:@"-"].location == NSNotFound) {
+            NSRegularExpression *regex = [[NSRegularExpression alloc] initWithPattern:@"[0-9]" options:0 error:NULL];
+            NSInteger *matchLocation = [regex rangeOfFirstMatchInString:mutableSideMargin options:nil range:NSMakeRange(0, [mutableSideMargin length])].location;
+            [mutableSideMargin insertString:@"-" atIndex:matchLocation];
         } else {
-            invertedSideMargin = [sideMargin stringByReplacingOccurrencesOfString:@"-" withString:@""];
+            mutableSideMargin = [mutableSideMargin stringByReplacingOccurrencesOfString:@"-" withString:@""];
         }
 
-        [view constrainWidthToView:self predicate:invertedSideMargin];
+        if ([mutableSideMargin rangeOfString:@">"].location != NSNotFound) {
+            mutableSideMargin = [mutableSideMargin stringByReplacingOccurrencesOfString:@">" withString:@"<"];
+        } else if ([mutableSideMargin rangeOfString:@"<"].location != NSNotFound) {
+            mutableSideMargin = [mutableSideMargin stringByReplacingOccurrencesOfString:@"<" withString:@">"];
+        }
+
+        [view constrainWidthToView:self predicate:[mutableSideMargin copy]];
         [view alignCenterXWithView:self predicate:nil];
     }
 


### PR DESCRIPTION
When trying to change some sideMargin constraints, I learned that there was no handling for constraints with a relationship of greater than or less than. closes https://github.com/orta/ORStackView/issues/14.

I think in the future it would be best to take this a step further and instead of constraining the width and aligning center, actually align the leading and trailing edges using the sideMargin value provided. Right now the left and right margins will each be 1/2 of the sideMargin provided, which is a bit misleading.
