### PR TITLE
Fix crashing on iOS7

### DIFF
--- a/Classes/ios/ORStackScrollView.m
+++ b/Classes/ios/ORStackScrollView.m
@@ -52,7 +52,10 @@
 }
 
 - (void)updateConstraints {
-    [self removeConstraints:self.contentConstraints];
+    for (NSLayoutConstraint *constraint in self.contentConstraints) {
+        [self removeConstraint:constraint];
+    }
+    
     if (self.stackView.direction == ORStackViewDirectionHorizontal) {
         self.contentConstraints = [_stackView constrainHeightToView:self predicate:@""];
     } else {


### PR DESCRIPTION
On iOS7 ``` [self removeConstraints:]``` does not accept nil:(